### PR TITLE
Implement `defn`

### DIFF
--- a/src/nedap/utils/spec/impl/def_with_doc.clj
+++ b/src/nedap/utils/spec/impl/def_with_doc.clj
@@ -1,0 +1,11 @@
+(ns nedap.utils.spec.impl.def-with-doc
+  (:require
+   [clojure.spec.alpha :as spec]
+   [nedap.utils.spec.api :refer [check!]]))
+
+(defmacro def-with-doc
+  [spec-name docstring spec]
+  {:pre [(check! qualified-keyword? spec-name
+                 string? docstring
+                 some? spec)]}
+  `(spec/def ~spec-name ~spec))

--- a/src/nedap/utils/spec/impl/defn.clj
+++ b/src/nedap/utils/spec/impl/defn.clj
@@ -1,0 +1,51 @@
+(ns nedap.utils.spec.impl.defn
+  (:require
+   [clojure.core.specs.alpha :as specs]
+   [nedap.utils.spec.api :refer [check!]]
+   [nedap.utils.spec.impl.parsing :refer [extract-specs-from-metadata fntails]]))
+
+(defn add-prepost [tails ret-spec]
+  (->> tails
+       (map (fn [[args maybe-prepost & maybe-rest-of-body :as tail]]
+              (let [rest-of-body? (-> maybe-rest-of-body seq)
+                    body (if rest-of-body?
+                           (cons maybe-rest-of-body rest-of-body?)
+                           [maybe-prepost])
+                    {inner-ret-spec :spec} (-> args meta extract-specs-from-metadata first)
+                    args-sigs (map (fn [arg arg-meta]
+                                     (merge {:arg arg}
+                                            (->> arg-meta extract-specs-from-metadata first)))
+                                   args
+                                   (map meta args))
+                    args-check-form (->> args-sigs
+                                         (filter :spec)
+                                         (map (fn [{:keys [spec arg]}]
+                                                [spec arg]))
+                                         (apply concat)
+                                         (apply list `check!))
+                    prepost (cond-> (when-not (= [maybe-prepost] body)
+                                      maybe-prepost)
+                              true (update :pre vec) ;; maybe there was no :pre. Ensure it's a vector
+                              true (update :post vec) ;; maybe there was no :post. Ensure it's a vector
+                              (-> args-check-form count (> 1)) (update :pre conj args-check-form)
+                              ret-spec (update :post conj (list `check! ret-spec '%))
+                              inner-ret-spec (update :post conj (list `check! inner-ret-spec '%))
+                              ;; ret-spec and inner-ret-spec may be identical
+                              true (update :post (comp vec distinct)))]
+                (apply list args prepost body))))))
+
+(defn impl
+  [[name & tail :as args]]
+  {:pre [(check! ::specs/defn-args args)]}
+  (let [{ret-spec :spec
+         ret-ann :type-annotation} (-> name meta extract-specs-from-metadata first)
+        tail (if (-> tail first list?)
+               tail
+               (list tail))
+        tails (fntails name tail)
+        tails (add-prepost tails ret-spec)
+        name-had-tag? (-> name meta keys #{:tag})
+        name (if name-had-tag?
+               name
+               (vary-meta name dissoc :tag))]
+    (apply list `clojure.core/defn (cons name tails))))

--- a/src/nedap/utils/spec/impl/parsing.clj
+++ b/src/nedap/utils/spec/impl/parsing.clj
@@ -1,0 +1,61 @@
+(ns nedap.utils.spec.impl.parsing
+  (:require
+   [nedap.utils.spec.impl.check :refer [check!]]
+   [nedap.utils.specs :as specs]))
+
+(defn proper-spec-metadata? [metadata-map extracted-specs]
+  (if (-> extracted-specs count #{1})
+    (check! ::specs/spec-metadata metadata-map)
+    true))
+
+(defn extract-specs-from-metadata [metadata-map]
+  {:post [(check! #{0 1} (count %)
+                  (partial proper-spec-metadata? metadata-map) %)]}
+  (->> metadata-map
+       (map (fn [[k v]]
+              (cond
+                (and (qualified-keyword? k)
+                     (true? v))
+                {:spec k
+                 :type-annotation nil}
+
+                (and (qualified-keyword? k)
+                     (-> k name #{"spec"}))
+                {:spec v
+                 :type-annotation nil}
+
+                (and (#{:tag} k)
+                     (symbol? v))
+                {:spec (list 'fn ['x]
+                             (list `instance? v 'x))
+                 :type-annotation (resolve v)})))
+       (filter some?)))
+
+(defn ^{:author "Rich Hickey"
+        :license "Eclipse Public License 1.0"
+        :comment "Adapted from clojure.core/defn, with modifications."}
+  fntails
+  [name & fdecl]
+  {:pre [(check! symbol? name)]}
+  (let [m (if (string? (first fdecl))
+            {:doc (first fdecl)}
+            {})
+        fdecl (if (string? (first fdecl))
+                (next fdecl)
+                fdecl)
+        m (if (map? (first fdecl))
+            (conj m (first fdecl))
+            m)
+        fdecl (if (map? (first fdecl))
+                (next fdecl)
+                fdecl)
+        fdecl (if (vector? (first fdecl))
+                (list fdecl)
+                fdecl)
+        m (if (map? (last fdecl))
+            (conj m (last fdecl))
+            m)
+        fdecl (if (map? (last fdecl))
+                (butlast fdecl)
+                fdecl)]
+    (first fdecl)))

--- a/src/nedap/utils/specs.clj
+++ b/src/nedap/utils/specs.clj
@@ -1,0 +1,42 @@
+(ns nedap.utils.specs
+  "Specs for this library."
+  (:require
+   [clojure.spec.alpha :as spec]
+   [nedap.utils.spec.impl.def-with-doc :refer [def-with-doc]]))
+
+(def-with-doc ::concise-format
+  "Example: ^::foo
+(i.e. namespace-qualified spec name with a `true` value)"
+  (spec/and map?
+            (partial some (fn [[k v]]
+                            (and (qualified-keyword? k)
+                                 (true? v))))))
+
+(def-with-doc ::explicit-format
+  "Example: ^{::spec ::foo}
+(i.e. using a namespace-qualified ::spec key, with an arbitrary spec as a value)"
+  (spec/and map?
+            (partial some (fn [[k v]]
+                            (qualified-keyword? k)
+                            (-> k name #{"spec"})))))
+
+(def-with-doc ::type-hint
+  "Example: ^Int
+(i.e. a regular Clojure type hint, from which a spec and efficient code will be emmited)"
+  (spec/and map?
+            (partial some (fn [[k v]]
+                            (and (= :tag k)
+                                 (symbol? v))))))
+
+(def-with-doc ::spec-metadata
+  "'Spec metadata' is metadata passed to this namespace's `#'defn` and `#'defprotocol`, in:
+
+   * argument positions, i.e. before a given argument in the argument vector; and
+   * return value positions, i.e. before a function's name, or before an argument vector.
+
+  A defn with return value metadata for both its name and argument vector will emit spec checking for both.
+
+  Refer to the tests (and the project's README) for examples, and to this spec/ns for format descriptions + docstrings."
+  (spec/or :concise-format ::concise-format
+           :explicit-format ::explicit-format
+           :type-hint ::type-hint))

--- a/test/unit/nedap/utils/speced/defn.clj
+++ b/test/unit/nedap/utils/speced/defn.clj
@@ -1,0 +1,308 @@
+(ns unit.nedap.utils.speced.defn
+  "NOTE: all these demonstrate the following aspect documented in `:nedap.utils.specs/spec-metadata`:
+
+  > A defn with return value metadata for both its name and argument vector will emit spec checking for both.
+
+  In practice, that is completely optional and you are free to use 2, 1, or 0 return value hints in any position of your choice."
+  (:require
+   [clojure.spec.alpha :as spec]
+   [clojure.test :refer :all]
+   [nedap.utils.speced :as sut]))
+
+(spec/def ::age pos?)
+
+(spec/def ::temperature int?)
+
+(spec/def ::name (spec/and string? (fn [x]
+                                     (-> x count (< 10)))))
+
+(spec/def ::present? some?)
+
+(doseq [[k v] {:no-metadata '(sut/defn no-metadata [x]
+                               (-> x (* x) str))
+
+               :no-metadata-n '(sut/defn no-metadata-n
+                                 ([x]
+                                  (-> x (* x) str))
+                                 ([x y]
+                                  (-> x (* y) str)))
+
+               :concise-metadata '(sut/defn ^::present?
+                                    concise-metadata
+                                    ^::name
+                                    [^::age x]
+                                    (-> x (* x) str))
+
+               :concise-metadata-n '(sut/defn ^::present?
+                                      concise-metadata-n
+                                      (^::name
+                                       [^::age x]
+                                       (-> x (* x) str))
+                                      (^::name
+                                       [^::age x ^::temperature y]
+                                       (-> x (* y) str)))
+
+               :explicit-metadata '(sut/defn ^{::spec ::present?}
+                                     explicit-metadata
+                                     ^{::spec ::name}
+                                     [^{::spec ::age} x]
+                                     (-> x (* x) str))
+
+               :explicit-metadata-n '(sut/defn ^{::spec ::present?}
+                                       explicit-metadata-n
+                                       (^{::spec ::name}
+                                        [^{::spec ::age} x]
+                                        (-> x (* x) str))
+                                       (^{::spec ::name}
+                                        [^{::spec ::age} x
+                                         ^{::spec ::temperature} y]
+                                        (-> x (* y) str)))
+
+               :type-hinted-metadata '(sut/defn ^Object
+                                        type-hinted-metadata
+                                        ^String
+                                        [^Long x]
+                                        (when (< 0 x 100)
+                                          (-> x (* x) str)))
+
+               :type-hinted-metadata-n '(sut/defn ^Object
+                                          type-hinted-metadata-n
+                                          (^String [^Long x]
+                                           (when (< 0 x 100)
+                                             (-> x (* x) str)))
+
+                                          (^String [^Long x ^Long y]
+                                           (when (< 0 x 100)
+                                             (-> x (* y) str))))}]
+  (eval v)
+  (eval `(def ~(-> k
+                   name
+                   (str "-macroexpansion")
+                   symbol)
+           ~(list 'quote (macroexpand v)))))
+
+(deftest macroexpansion
+  (testing "It macroexpands to known-good (and evidently-good) forms"
+    (are [x y] (= x y)
+      no-metadata-macroexpansion '(def no-metadata (clojure.core/fn ([x]
+                                                                     {:pre [], :post []}
+                                                                     (-> x (* x) str))))
+      no-metadata-n-macroexpansion '(def no-metadata-n
+                                      (clojure.core/fn
+                                        ([x]
+                                         {:pre [], :post []}
+                                         (-> x (* x) str))
+                                        ([x y]
+                                         {:pre [], :post []}
+                                         (-> x (* y) str))))
+      concise-metadata-macroexpansion '(def concise-metadata
+                                         (clojure.core/fn
+                                           ([x]
+                                            {:pre
+                                             [(nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/age x)],
+                                             :post
+                                             [(nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/present? %)
+                                              (nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/name %)]}
+                                            (-> x (* x) str))))
+      concise-metadata-n-macroexpansion '(def concise-metadata-n
+                                           (clojure.core/fn
+                                             ([x]
+                                              {:pre
+                                               [(nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/age x)],
+                                               :post
+                                               [(nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/present? %)
+                                                (nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/name  %)]}
+                                              (-> x (* x) str))
+                                             ([x y]
+                                              {:pre
+                                               [(nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/age x
+                                                                             :unit.nedap.utils.speced.defn/temperature y)],
+                                               :post
+                                               [(nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/present? %)
+                                                (nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/name  %)]}
+                                              (-> x (* y) str))))
+      explicit-metadata-macroexpansion '(def explicit-metadata
+                                          (clojure.core/fn
+                                            ([x]
+                                             {:pre
+                                              [(nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/age x)],
+                                              :post
+                                              [(nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/present? %)
+                                               (nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/name %)]}
+                                             (-> x (* x) str))))
+      explicit-metadata-n-macroexpansion '(def explicit-metadata-n
+                                            (clojure.core/fn
+                                              ([x]
+                                               {:pre
+                                                [(nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/age x)],
+                                                :post
+                                                [(nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/present? %)
+                                                 (nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/name  %)]}
+                                               (-> x (* x) str))
+                                              ([x y]
+                                               {:pre
+                                                [(nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/age x
+                                                                              :unit.nedap.utils.speced.defn/temperature y)],
+                                                :post
+                                                [(nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/present? %)
+                                                 (nedap.utils.spec.api/check! :unit.nedap.utils.speced.defn/name  %)]}
+                                               (-> x (* y) str))))
+      type-hinted-metadata-macroexpansion '(def type-hinted-metadata
+                                             (clojure.core/fn
+                                               ([x]
+                                                {:pre
+                                                 [(nedap.utils.spec.api/check! (fn [x] (clojure.core/instance? Long x)) x)],
+                                                 :post
+                                                 [(nedap.utils.spec.api/check! (fn [x] (clojure.core/instance? Object x)) %)
+                                                  (nedap.utils.spec.api/check! (fn [x] (clojure.core/instance? String x)) %)]}
+                                                (when (< 0 x 100)
+                                                  (-> x (* x) str)))))
+      type-hinted-metadata-n-macroexpansion '(def type-hinted-metadata-n
+                                               (clojure.core/fn
+                                                 ([x]
+                                                  {:pre
+                                                   [(nedap.utils.spec.api/check!
+                                                     (fn [x] (clojure.core/instance? Long x))
+                                                     x)],
+                                                   :post
+                                                   [(nedap.utils.spec.api/check!
+                                                     (fn [x] (clojure.core/instance? Object x))
+                                                     %)
+                                                    (nedap.utils.spec.api/check!
+                                                     (fn [x] (clojure.core/instance? String x))
+                                                     %)]}
+                                                  (when (< 0 x 100) (-> x (* x) str)))
+                                                 ([x y]
+                                                  {:pre
+                                                   [(nedap.utils.spec.api/check!
+                                                     (fn [x] (clojure.core/instance? Long x))
+                                                     x
+                                                     (fn [x] (clojure.core/instance? Long x))
+                                                     y)],
+                                                   :post
+                                                   [(nedap.utils.spec.api/check!
+                                                     (fn [x] (clojure.core/instance? Object x))
+                                                     %)
+                                                    (nedap.utils.spec.api/check!
+                                                     (fn [x] (clojure.core/instance? String x))
+                                                     %)]}
+                                                  (when (< 0 x 100) (-> x (* y) str))))))))
+
+(deftest correct-execution
+  (testing "Arity 1"
+    (are [f] (= "64" (f 8))
+      no-metadata
+      no-metadata-n
+      concise-metadata
+      concise-metadata-n
+      explicit-metadata
+      explicit-metadata-n
+      type-hinted-metadata
+      type-hinted-metadata-n))
+
+  (testing "Arity 2"
+    (are [f] (= "16" (f 8 2))
+      no-metadata-n
+      concise-metadata-n
+      explicit-metadata-n
+      type-hinted-metadata-n)))
+
+(deftest preconditions-are-checked
+  (testing "Arity 1"
+    (with-out-str
+      (let [arg 0]
+        (are [expectation f] (case expectation
+                               :not-thrown (= "0" (f arg))
+                               :thrown (try
+                                         (f arg 1)
+                                         false
+                                         (catch Exception e
+                                           (-> e ex-data :spec))))
+          :not-thrown no-metadata-n
+          :thrown     concise-metadata-n
+          :thrown     explicit-metadata-n
+          :thrown     type-hinted-metadata-n))))
+
+  (testing "Arity 2"
+    (with-out-str
+      (let [arg 0]
+        (are [expectation f] (case expectation
+                               :not-thrown (= "0" (f arg))
+                               :thrown (try
+                                         (f arg)
+                                         false
+                                         (catch Exception e
+                                           (-> e ex-data :spec))))
+          :not-thrown no-metadata
+          :not-thrown no-metadata-n
+          :thrown     concise-metadata
+          :thrown     concise-metadata-n
+          :thrown     explicit-metadata
+          :thrown     explicit-metadata-n
+          :thrown     type-hinted-metadata
+          :thrown     type-hinted-metadata-n)))))
+
+(deftest postconditions-are-checked
+  (testing "Arity 1"
+    (with-out-str
+      (let [arg 99999]
+        (are [expectation f] (case expectation
+                               :not-thrown (= "9999800001" (f arg))
+                               :thrown (try
+                                         (f arg)
+                                         false
+                                         (catch Exception e
+                                           (-> e ex-data :spec))))
+          :not-thrown no-metadata
+          :not-thrown no-metadata-n
+          :thrown     concise-metadata
+          :thrown     concise-metadata-n
+          :thrown     explicit-metadata
+          :thrown     explicit-metadata-n
+          :thrown     type-hinted-metadata
+          :thrown     type-hinted-metadata-n))))
+
+  (testing "Arity 2"
+    (with-out-str
+      (let [arg1 99999
+            arg2 100000]
+        (are [expectation f] (case expectation
+                               :not-thrown (= "9999900000" (f arg1 arg2))
+                               :thrown (try
+                                         (f arg1 arg2)
+                                         false
+                                         (catch Exception e
+                                           (-> e ex-data :spec))))
+          :not-thrown no-metadata-n
+          :thrown     concise-metadata-n
+          :thrown     explicit-metadata-n
+          :thrown     type-hinted-metadata-n)))))
+
+;; Plain defn, not sut/defn
+(defn plain-defn-arity-1 ^String [s])
+
+;; Plain defn, not sut/defn
+(defn plain-defn-arity-n
+  (^String [x])
+  (^String [x y]))
+
+(deftest type-hint-emission
+  (testing "Emitted type hints matches Clojure's behavior"
+
+    (are [v] (-> v meta :tag nil?)
+      #'plain-defn-arity-1
+      #'type-hinted-metadata meta
+      #'type-hinted-metadata-n meta)
+
+    (are [v] (-> v meta :arglists first meta :tag #{`String})
+      #'type-hinted-metadata
+      #'plain-defn-arity-1)
+
+    (are [v] (->> v
+                  meta
+                  :arglists
+                  (map meta)
+                  (map :tag)
+                  (every? #{`String}))
+      #'type-hinted-metadata-n
+      #'plain-defn-arity-n)))


### PR DESCRIPTION
Fixes #10 

I implemented `speced/defn`, which is analog to `speced/defprotocol`.

* Exact same syntax than clojure.core's
* Three ways of passing specs as metadata
  * Which is why this branch is branched off (and diffed against) https://github.com/nedap/utils.spec/pull/11
* Type hints are actually emitted
  * Faster execution
  * Possibly it could help a variety of IDEs offer better autocompletion
* Speced, doc'ed, tested