### PR TITLE
👷🏼‍Add deploy step to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,8 @@ workflows:
           filters:
             branches:
               only: /.*/
-
+            tags:
+              only: /^v\d+\.\d+\.\d+(-[A-Z]*)*$/
 
 
       - jfrog:


### PR DESCRIPTION
# Deploy will happen when
 - any commits is tagged with a version matching ` /^v\d+\.\d+\.\d+(-[A-Z]*)*$/`
      - so `v0.0.1` and `v0.0.1-SNAPSHOT` trigger a deploy,
      - `v0.1` and `0.0.1` won't
 - `-SNAPSHOT` tags will trigger a deploy, but won't succeed (no clojars creds)


Keep in mind we can't deploy `-SNAPSHOT`. and to update `README.md` and `project.clj`. which you could automate with
```bash
#!/bin/bash

TAG=`git describe --tags --abbrev=0`
VERSION=${TAG#?}

# update project.clj
lein change version set \"$VERSION\"

# update README.md line
sed -i '' "s/\[com.nedap.staffing-solutions\/utils.spec.*/\[com.nedap.staffing-solutions\/utils.spec \"$VERSION\"\]/g" README.md
```

but seemed out of scope for this pr