### PR TITLE
create a failing build

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                     {:username :env/artifactory_user
                      :password :env/artifactory_pass}}
 
-  :dependencies [[com.nedap.staffing-solutions/utils.test "0.1.0-alpha5"]
+  :dependencies [[com.nedap.staffing-solutions/utils.test "1.0.0"]
                  [expound "0.7.2"]
                  [org.clojure/clojure "1.10.1-beta2"]
                  [org.clojure/spec.alpha "0.1.143"]


### PR DESCRIPTION
This dep upgrade would fail with https://gist.githubusercontent.com/vemv/3fd022882c9b2533fb3d669df8bcfc48/raw/56a711137778b25f6c1710721c2b9b8c4ce016ff/gistfile1.txt , which at the very least seems to reveal a bug in Clojure error reporting.