### PR TITLE
Introduce `speced/let`, `speced/letfn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ That way, you can strengthen your defns with custom specs (expressed as metadata
 #### Coordinates
 
 ```clojure
-[com.nedap.staffing-solutions/speced.def "1.0.0"]
+[com.nedap.staffing-solutions/speced.def "1.1.0-alpha1"]
 ```
 
 > Note that self-hosted ClojureScript (e.g. Lumo) is unsupported at the moment.

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/speced.def "1.0.0"
+(defproject com.nedap.staffing-solutions/speced.def "1.1.0-alpha1"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[com.nedap.staffing-solutions/utils.spec "1.0.0"]
                  [com.nedap.staffing-solutions/utils.test "1.3.0"]

--- a/src/nedap/speced/def.cljc
+++ b/src/nedap/speced/def.cljc
@@ -4,11 +4,12 @@
   Please `:require` this namepace with the `speced` alias: `[nedap.speced.def :as speced]`.
 
   That way, you will invoke e.g. `speced/defprotocol` which is clean and clear."
-  (:refer-clojure :exclude [defn defprotocol doc fn let satisfies?])
+  (:refer-clojure :exclude [defn defprotocol doc fn let letfn satisfies?])
   (:require
    #?(:clj [clojure.test :as test])
    #?(:clj [nedap.speced.def.impl.fn :as impl.fn] :cljs [nedap.speced.def.impl.dummy :as impl.fn])
    #?(:clj [clojure.core.specs.alpha :as specs] :cljs [cljs.core.specs.alpha :as specs])
+   #?(:clj [nedap.speced.def.impl.letfn :as impl.letfn])
    #?(:clj [nedap.speced.def.impl.let-impl :as let-impl])
    [clojure.spec.alpha :as spec]
    [nedap.speced.def.doc :refer [doc-registry rebl-doc-registry]]
@@ -109,6 +110,23 @@
      [bindings & body]
      {:pre [(check! ::specs/bindings bindings)]}
      (let-impl/impl (-> &env :ns nil?) bindings body)))
+
+#?(:clj
+   (defmacro letfn
+     "Emits a spec-backed `letfn`, which uses `nedap.utils.spec.api/check!` at runtime
+  to verify that any metadata-annotated symbols satisfy the specs denoted by that metadata.
+
+  Has the exact same signature as `#'clojure.core/letfn`, with full support for arbitrarily nested destructuring and multiple arities.
+
+  Spec metadata follows the `:nedap.speced.def.specs/spec-metadata` 'syntaxes'.
+
+  Runtime-checking behavior is controlled with `#'clojure.core/*assert*`."
+     {:style/indent        [1 [[:defn]] :form]
+      :style.cljfmt/indent [[:block 1] [:inner 2 0]]}
+     [fnspecs & body]
+     (impl.letfn/impl (-> &env :ns nil?)
+                      fnspecs
+                      body)))
 
 #?(:clj
    (clojure.core/defn satisfies?

--- a/src/nedap/speced/def.cljc
+++ b/src/nedap/speced/def.cljc
@@ -4,11 +4,12 @@
   Please `:require` this namepace with the `speced` alias: `[nedap.speced.def :as speced]`.
 
   That way, you will invoke e.g. `speced/defprotocol` which is clean and clear."
-  (:refer-clojure :exclude [defn defprotocol doc fn satisfies?])
+  (:refer-clojure :exclude [defn defprotocol doc fn let satisfies?])
   (:require
    #?(:clj [clojure.test :as test])
    #?(:clj [nedap.speced.def.impl.fn :as impl.fn] :cljs [nedap.speced.def.impl.dummy :as impl.fn])
    #?(:clj [clojure.core.specs.alpha :as specs] :cljs [cljs.core.specs.alpha :as specs])
+   #?(:clj [nedap.speced.def.impl.let-impl :as let-impl])
    [clojure.spec.alpha :as spec]
    [nedap.speced.def.doc :refer [doc-registry rebl-doc-registry]]
    [nedap.speced.def.impl.def-with-doc]
@@ -28,8 +29,8 @@
      {:pre [(check! qualified-keyword? spec-name
                     string?            docstring
                     some?              spec)]}
-     (let [ref `doc-registry
-           ref2 `rebl-doc-registry]
+     (clojure.core/let [ref `doc-registry
+                        ref2 `rebl-doc-registry]
        `(nedap.speced.def.impl.def-with-doc/def-with-doc ~spec-name ~docstring ~spec ~ref ~ref2))))
 
 #?(:clj
@@ -43,13 +44,13 @@
 #?(:clj
    (defmacro defprotocol
      "Emits a spec-backed defprotocol, which uses `nedap.utils.spec.api/check!` at runtime
-  to verify that specs of return values and arguments satify the (optional) specs passed as metadata.
+  to verify that the return values and arguments satify the (optional) specs passed as metadata.
 
   Has the exact same signature as `clojure.core/defprotocol`, with the constraint that docstrings are mandatory.
 
   Each method name, and each argument, observes spec metadata as per the `:nedap.speced.def.specs/spec-metadata` spec.
 
-  The implementation is backed by Clojure's `:pre`/`:post`, therefore runtime-checking behavior is controlled with `*assert*``.
+  The implementation is backed by Clojure's `:pre`/`:post`, therefore runtime-checking behavior is controlled with `*assert*`.
 
   When implementing the protocol, each method must be prefixed with `--`.
 
@@ -62,13 +63,13 @@
 #?(:clj
    (defmacro defn
      "Emits a spec-backed defn, which uses `nedap.utils.spec.api/check!` at runtime
-  to verify that specs of return values and arguments satify the (optional) specs passed as metadata.
+  to verify that the return values and arguments satify the (optional) specs passed as metadata.
 
   Has the exact same signature as `clojure.core/defn`, with full support for all its variations.
 
-  Each return value position, and each argument, observes spec metadata as per the `:nedap.speced.def.specs/spec-metadata`` spec.
+  Each return value position, and each argument, observes spec metadata as per the `:nedap.speced.def.specs/spec-metadata` spec.
 
-  The implementation is backed by Clojure's `:pre`/`:post`, therefore runtime-checking behavior is controlled with `*assert*``."
+  The implementation is backed by Clojure's `:pre`/`:post`, therefore runtime-checking behavior is controlled with `*assert*`."
      {:style/indent        :defn
       :style.cljfmt/indent [[:inner 0]]}
      [& args]
@@ -79,19 +80,35 @@
 #?(:clj
    (defmacro fn
      "Emits a spec-backed fn, which uses `nedap.utils.spec.api/check!` at runtime
-  to verify that specs of return values and arguments satify the (optional) specs passed as metadata.
+  to verify that the return values and arguments satify the (optional) specs passed as metadata.
 
   Has the exact same signature as `clojure.core/fn`, with full support for all its variations.
 
-  Each return value position, and each argument, observes spec metadata as per the `:nedap.speced.def.specs/spec-metadata`` spec.
+  Each return value position, and each argument, observes spec metadata as per the `:nedap.speced.def.specs/spec-metadata` spec.
 
-  The implementation is backed by Clojure's `:pre`/`:post`, therefore runtime-checking behavior is controlled with `*assert*``."
+  The implementation is backed by Clojure's `:pre`/`:post`, therefore runtime-checking behavior is controlled with `*assert*`."
      {:style/indent        :defn
       :style.cljfmt/indent [[:inner 0]]}
      [& args]
      {:pre [(check! ::impl.fn/fn args)]}
      (impl.fn/impl (-> &env :ns nil?)
                    args)))
+
+#?(:clj
+   (defmacro let
+     "Emits a spec-backed `let`, which uses `nedap.utils.spec.api/check!` at runtime
+  to verify that any metadata-annotated symbols satisfy the specs denoted by that metadata.
+
+  Has the exact same signature as `#'clojure.core/let`, with full support for arbitrarily nested destructuring.
+
+  Spec metadata follows the `:nedap.speced.def.specs/spec-metadata` 'syntaxes'.
+
+  Runtime-checking behavior is controlled with `#'clojure.core/*assert*`."
+     {:style/indent        1
+      :style.cljfmt/indent [[:block 1]]}
+     [bindings & body]
+     {:pre [(check! ::specs/bindings bindings)]}
+     (let-impl/impl (-> &env :ns nil?) bindings body)))
 
 #?(:clj
    (clojure.core/defn satisfies?
@@ -115,6 +132,6 @@ for indicating that that spec is nilable."
      ;; (is (spec-assertion-thrown? s expr))
      ;; Asserts that evaluating expr throws an ExceptionInfo related to spec-symbol s.
      ;; Returns the exception thrown.
-     (let [spec-sym (second form)
-           body     (nthnext form 2)]
+     (clojure.core/let [spec-sym (second form)
+                        body     (nthnext form 2)]
        (nedap.speced.def.impl.spec-assertion/spec-assertion-thrown? msg spec-sym body))))

--- a/src/nedap/speced/def/impl/let_impl.cljc
+++ b/src/nedap/speced/def/impl/let_impl.cljc
@@ -1,0 +1,35 @@
+(ns nedap.speced.def.impl.let-impl
+  "`-impl` suffix is there to avoid a Closure warning."
+  (:require
+   [nedap.speced.def.impl.analysis :refer [process-name-and-tails]]
+   [nedap.utils.spec.api :refer [check!]]))
+
+(defn add-assertion [binding assertion]
+  {:pre [(check! #{0 1} (count assertion))]}
+  (cond-> binding
+    (seq assertion)
+    (conj (gensym) (first assertion))))
+
+(defn impl [clj? bindings body]
+  {:pre [(check! boolean? clj?)]}
+  (let [bindings (->> bindings
+                      (partition 2)
+                      (map (fn [[left right]]
+                             (let [analysis-result (process-name-and-tails {:tail (list [left])
+                                                                            :name nil
+                                                                            :clj? clj?})
+                                   argv (-> analysis-result :tails ffirst)
+                                   _ (assert (check! vector? argv
+                                                     #{1}    (count argv)))
+                                   left (first argv)
+                                   prepost (-> analysis-result :tails first second)
+                                   _ (assert (check! map? prepost))
+                                   assertion (-> prepost :pre)]
+                               [left right '_ assertion])))
+                      (map (fn [[left right _ assertion]]
+                             {:pre [(check! some? left
+                                            #{'_} _)]}
+                             (add-assertion [left right] assertion)))
+                      (apply concat)
+                      (vec))]
+    `(let ~bindings ~@body)))

--- a/src/nedap/speced/def/impl/letfn.cljc
+++ b/src/nedap/speced/def/impl/letfn.cljc
@@ -1,0 +1,15 @@
+(ns nedap.speced.def.impl.letfn
+  (:require
+   [nedap.speced.def.impl.analysis :refer [process-name-and-tails]]
+   [nedap.utils.spec.api :refer [check!]]))
+
+(defn impl [clj? fnspecs body]
+  {:pre [(check! boolean? clj?)]}
+  (let [fnspecs (->> fnspecs
+                     (mapv (fn [[fn-name & tail]]
+                             (->> (process-name-and-tails {:name fn-name
+                                                           :tail tail
+                                                           :clj? clj?})
+                                  (:tails)
+                                  (cons fn-name)))))]
+    `(letfn ~fnspecs ~@body)))

--- a/test/nedap/utils/spec/test_runner.cljs
+++ b/test/nedap/utils/spec/test_runner.cljs
@@ -17,6 +17,7 @@
    [unit.nedap.speced.def.fn]
    [unit.nedap.speced.def.impl.parsing.instance-spec]
    [unit.nedap.speced.def.let-test]
+   [unit.nedap.speced.def.letfn]
    [unit.nedap.speced.def.spec-assertion]))
 
 (nodejs/enable-util-print!)
@@ -37,6 +38,7 @@
    'unit.nedap.speced.def.defprotocol.type-hinting
    'unit.nedap.speced.def.fn
    'unit.nedap.speced.def.impl.parsing.instance-spec
+   'unit.nedap.speced.def.letfn
    'unit.nedap.speced.def.let-test
    'unit.nedap.speced.def.spec-assertion))
 

--- a/test/nedap/utils/spec/test_runner.cljs
+++ b/test/nedap/utils/spec/test_runner.cljs
@@ -16,6 +16,7 @@
    [unit.nedap.speced.def.defprotocol.type-hinting]
    [unit.nedap.speced.def.fn]
    [unit.nedap.speced.def.impl.parsing.instance-spec]
+   [unit.nedap.speced.def.let-test]
    [unit.nedap.speced.def.spec-assertion]))
 
 (nodejs/enable-util-print!)
@@ -36,6 +37,7 @@
    'unit.nedap.speced.def.defprotocol.type-hinting
    'unit.nedap.speced.def.fn
    'unit.nedap.speced.def.impl.parsing.instance-spec
+   'unit.nedap.speced.def.let-test
    'unit.nedap.speced.def.spec-assertion))
 
 (set! *main-cli-fn* -main)

--- a/test/unit/nedap/speced/def/let_test.cljc
+++ b/test/unit/nedap/speced/def/let_test.cljc
@@ -1,0 +1,111 @@
+(ns unit.nedap.speced.def.let-test
+  "This ns uses `-test` suffix for avoiding a Closure warning."
+  (:require
+   #?(:clj [clojure.spec.alpha :as spec] :cljs [cljs.spec.alpha :as spec])
+   #?(:clj [clojure.test :refer [deftest testing are is use-fixtures]] :cljs [cljs.test :refer-macros [deftest testing is are] :refer [use-fixtures]])
+   [clojure.string :as string]
+   [nedap.speced.def :as sut]
+   [nedap.speced.def.impl.parsing :as impl.parsing]
+   [nedap.utils.spec.api :refer [check!]]
+   [nedap.utils.test.api :refer [macroexpansion=]]
+   [nedap.utils.test.api :refer [meta=]]
+   [unit.nedap.test-helpers :refer [every-and-at-least-one?]])
+  #?(:cljs (:require-macros [unit.nedap.speced.def.let-test :refer [let-specimen-1 let-specimen-2 let-specimen-3]])))
+
+#?(:clj
+   (defmacro let-specimen-1 []
+     (if (-> &env :ns nil?)
+       '(sut/let [^string? a "A string"
+                  {:keys [^long b]} {:b 52}
+                  not-speced :anything]
+          [a b])
+       '(sut/let [^string? a "A string"
+                  {:keys [^number b]} {:b 52}
+                  not-speced :anything]
+          [a b]))))
+
+#?(:clj
+   (defmacro let-specimen-2 []
+     (if (-> &env :ns nil?)
+       '(sut/let [^string? a nil
+                  {:keys [^long b]} {:b 52}
+                  not-speced :anything]
+          [a b])
+       '(sut/let [^string? a nil
+                  {:keys [^number b]} {:b 52}
+                  not-speced :anything]
+          [a b]))))
+
+#?(:clj
+   (defmacro let-specimen-3 []
+     (if (-> &env :ns nil?)
+       '(sut/let [^string? a "A string"
+                  {:keys [^long b]} {:b "NaN"}
+                  not-speced :anything]
+          [a b])
+       '(sut/let [^string? a "A string"
+                  {:keys [^number b]} {:b "NaN"}
+                  not-speced :anything]
+          [a b]))))
+
+#?(:clj
+   (defmacro macroexpansion-specimens []
+     (let [xs {:specimen-1 (macroexpand-1 (macroexpand-1 '(let-specimen-1)))}]
+       (->> xs
+            (map (fn [[k v]]
+                   [k (list 'quote v)]))
+            (into {})))))
+
+#?(:clj
+   (doseq [[k v] (macroexpansion-specimens)]
+     (eval `(def ~(-> k
+                      name
+                      (str "-macroexpansion")
+                      symbol)
+              ~(list 'quote v)))))
+
+#?(:clj
+   (deftest macroexpansions
+     (testing "It expands to a known-good, reasonable-looking form"
+       (is (macroexpansion= '(clojure.core/let [a "A string"
+                                                G__440105 (nedap.utils.spec.api/check! (clojure.spec.alpha/and
+                                                                                        string?
+                                                                                        (fn [x]
+                                                                                          (if (clojure.core/class? java.lang.String)
+                                                                                            (clojure.core/instance? java.lang.String x)
+                                                                                            (clojure.core/satisfies? java.lang.String x))))
+                                                                                       a)
+                                                {:keys [b]} {:b 52}
+                                                G__440105 (nedap.utils.spec.api/check! (fn [x]
+                                                                                         (if (clojure.core/class? java.lang.Long)
+                                                                                           (clojure.core/instance? java.lang.Long x)
+                                                                                           (clojure.core/satisfies? java.lang.Long x)))
+                                                                                       b)
+                                                not-speced :anything]
+                               [a b])
+                            specimen-1-macroexpansion)))
+     (testing "type hint metadata is inferred"
+       (let [[string-hinted
+              _
+              {[long-hinted] :keys}] (->> specimen-1-macroexpansion
+                                          second
+                                          (partition 2)
+                                          (map first))]
+         (is (meta= string-hinted
+                    (with-meta 'a {:tag `String})))
+         (is (meta= long-hinted
+                    (with-meta 'b {:tag 'long})))))))
+
+(deftest correct-execution
+  (is (= ["A string" 52]
+         (let-specimen-1))))
+
+(def validation-failed #"Validation failed")
+
+(deftest assertions-are-checked
+  (are [specimen] (thrown-with-msg? #?(:clj Exception :cljs js/Error)
+                                    validation-failed
+                                    (with-out-str
+                                      (specimen)))
+    let-specimen-2
+    let-specimen-3))

--- a/test/unit/nedap/speced/def/letfn.cljc
+++ b/test/unit/nedap/speced/def/letfn.cljc
@@ -1,0 +1,189 @@
+(ns unit.nedap.speced.def.letfn
+  (:require
+   #?(:clj [clojure.spec.alpha :as spec] :cljs [cljs.spec.alpha :as spec])
+   #?(:clj [clojure.test :refer [deftest testing are is use-fixtures]] :cljs [cljs.test :refer-macros [deftest testing is are] :refer [use-fixtures]])
+   [clojure.string :as string]
+   [nedap.speced.def :as sut]
+   [nedap.speced.def.impl.parsing :as impl.parsing]
+   [nedap.utils.spec.api :refer [check!]]
+   [nedap.utils.test.api :refer [macroexpansion=]]
+   [nedap.utils.test.api :refer [meta=]]
+   [unit.nedap.test-helpers :refer [every-and-at-least-one?]])
+  #?(:cljs (:require-macros [unit.nedap.speced.def.letfn :refer [letfn-specimen-1 let-specimen-2 let-specimen-3]])))
+
+(defn fnspecs-example [clj?]
+  (if clj?
+    '[(single-signature [^string? a
+                         {:keys [^long b]}
+                         not-speced]
+                        [a b not-speced])
+      (single-signature-wrapped ([^string? a
+                                  {:keys [^long b]}
+                                  not-speced]
+                                 [a b not-speced]))
+      (multiple-signatures
+       ([^string? a
+         {:keys [^long b]}]
+        [a b])
+       ([^string? a
+         {:keys [^long b]}
+         not-speced]
+        [a b not-speced]))]
+    '[(single-signature [^string? a
+                         {:keys [^number b]}
+                         not-speced]
+                        [a b not-speced])
+      (single-signature-wrapped ([^string? a
+                                  {:keys [^number b]}
+                                  not-speced]
+                                 [a b not-speced]))
+      (multiple-signatures
+       ([^string? a
+         {:keys [^number b]}]
+        [a b])
+       ([^string? a
+         {:keys [^number b]}
+         not-speced]
+        [a b not-speced]))]))
+
+#?(:clj
+   (defmacro letfn-specimen-1 []
+     (let [clj? (-> &env :ns nil?)]
+       (list `sut/letfn
+             (fnspecs-example clj?)
+             '[(single-signature "a" {:b 2} ::anything)
+               (single-signature-wrapped "a" {:b 2} ::anything)
+               (multiple-signatures "a" {:b 2})
+               (multiple-signatures "a" {:b 2} ::anything)]))))
+
+#?(:clj
+   (defmacro let-specimen-2 []
+     (let [clj? (-> &env :ns nil?)]
+       (list `sut/letfn
+             (fnspecs-example clj?)
+             '[(single-signature nil {:b 2} ::anything)]))))
+
+#?(:clj
+   (defmacro let-specimen-3 []
+     (let [clj? (-> &env :ns nil?)]
+       (list `sut/letfn
+             (fnspecs-example clj?)
+             '[(single-signature nil {:b nil} ::anything)]))))
+
+#?(:clj
+   (defmacro macroexpansion-specimens []
+     (let [xs {:specimen-1 (macroexpand-1 (macroexpand-1 '(letfn-specimen-1)))}]
+       (->> xs
+            (map (fn [[k v]]
+                   [k (list 'quote v)]))
+            (into {})))))
+
+#?(:clj
+   (doseq [[k v] (macroexpansion-specimens)]
+     (eval `(def ~(-> k
+                      name
+                      (str "-macroexpansion")
+                      symbol)
+              ~(list 'quote v)))))
+
+#?(:clj
+   (deftest macroexpansions
+     (testing "It expands to a known-good, reasonable-looking form"
+       (is (macroexpansion= '(clojure.core/letfn [(single-signature ([a {:keys [b]} not-speced]
+                                                                     {:pre  [(nedap.utils.spec.api/check!
+                                                                              (fn [x]
+                                                                                (if (clojure.core/class? java.lang.Long)
+                                                                                  (clojure.core/instance? java.lang.Long x)
+                                                                                  (clojure.core/satisfies? java.lang.Long x)))
+                                                                              b
+
+                                                                              (clojure.spec.alpha/and
+                                                                               string?
+                                                                               (fn [x]
+                                                                                 (if (clojure.core/class? java.lang.String)
+                                                                                   (clojure.core/instance? java.lang.String x)
+                                                                                   (clojure.core/satisfies? java.lang.String x))))
+                                                                              a)],
+                                                                      :post []}
+                                                                     [a b not-speced]))
+                                                  (single-signature-wrapped ([a {:keys [b]} not-speced]
+                                                                             {:pre  [(nedap.utils.spec.api/check!
+                                                                                      (fn [x]
+                                                                                        (if (clojure.core/class? java.lang.Long)
+                                                                                          (clojure.core/instance? java.lang.Long x)
+                                                                                          (clojure.core/satisfies? java.lang.Long x)))
+                                                                                      b
+
+                                                                                      (clojure.spec.alpha/and
+                                                                                       string?
+                                                                                       (fn [x]
+                                                                                         (if (clojure.core/class? java.lang.String)
+                                                                                           (clojure.core/instance? java.lang.String x)
+                                                                                           (clojure.core/satisfies? java.lang.String x))))
+                                                                                      a)]
+                                                                              :post []}
+                                                                             [a b not-speced]))
+                                                  (multiple-signatures
+                                                    ([a {:keys [b]}]
+                                                     {:pre  [(nedap.utils.spec.api/check!
+                                                              (fn [x]
+                                                                (if (clojure.core/class? java.lang.Long)
+                                                                  (clojure.core/instance? java.lang.Long x)
+                                                                  (clojure.core/satisfies? java.lang.Long x)))
+                                                              b
+
+                                                              (clojure.spec.alpha/and
+                                                               string?
+                                                               (fn [x]
+                                                                 (if (clojure.core/class? java.lang.String)
+                                                                   (clojure.core/instance? java.lang.String x)
+                                                                   (clojure.core/satisfies? java.lang.String x))))
+                                                              a)],
+                                                      :post []}
+                                                     [a b])
+                                                    ([a {:keys [b]} not-speced]
+                                                     {:pre  [(nedap.utils.spec.api/check!
+                                                              (fn [x]
+                                                                (if (clojure.core/class? java.lang.Long)
+                                                                  (clojure.core/instance? java.lang.Long x)
+                                                                  (clojure.core/satisfies? java.lang.Long x)))
+                                                              b
+
+                                                              (clojure.spec.alpha/and
+                                                               string?
+                                                               (fn [x]
+                                                                 (if (clojure.core/class? java.lang.String)
+                                                                   (clojure.core/instance? java.lang.String x)
+                                                                   (clojure.core/satisfies? java.lang.String x))))
+                                                              a)]
+                                                      :post []}
+                                                     [a b not-speced]))]
+                               [(single-signature "a" {:b 2} ::anything)
+                                (single-signature-wrapped "a" {:b 2} ::anything)
+                                (multiple-signatures "a" {:b 2})
+                                (multiple-signatures "a" {:b 2} ::anything)])
+                            specimen-1-macroexpansion)))
+     (testing "type hint metadata is inferred"
+       (let [[string-hinted
+              {[long-hinted] :keys}] (->> specimen-1-macroexpansion second first second first)]
+         (is (meta= string-hinted
+                    (with-meta 'a {:tag `String})))
+         (is (meta= long-hinted
+                    (with-meta 'b {:tag 'long})))))))
+
+(deftest correct-execution
+  (is (= [["a" 2 ::anything]
+          ["a" 2 ::anything]
+          ["a" 2]
+          ["a" 2 ::anything]]
+         (letfn-specimen-1))))
+
+(def validation-failed #"Validation failed")
+
+(deftest assertions-are-checked
+  (are [specimen] (thrown-with-msg? #?(:clj Exception :cljs js/Error)
+                                    validation-failed
+                                    (with-out-str
+                                      (specimen)))
+    let-specimen-2
+    let-specimen-3))


### PR DESCRIPTION
## Brief

Self-explanatory.

## QA plan

Adopt the alpha in one of our main projects, try replacing `check!`s for `speced/let`, and if reasonable `letfn` for `speced/letfn`.

Green build _there_ (plus _here_) would suffice.

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [ ] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [ ] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
