### PR TITLE
Make `nedap.speced.def.impl.def-with-doc` cljs-friendlier

### DIFF
--- a/src/nedap/speced/def/impl/def_with_doc.cljc
+++ b/src/nedap/speced/def/impl/def_with_doc.cljc
@@ -23,9 +23,12 @@
      [spec-name docstring spec doc-registry symbol-doc-registry]
      {:pre [(check! qualified-keyword? spec-name
                     string?            docstring
-                    some?              spec
-                    (spec/and symbol?
-                              resolve) doc-registry)]}
+                    some?              spec)]}
+     (when (-> &env :ns nil?)
+       (check! (spec/and symbol?
+                         resolve) doc-registry
+               (spec/and symbol?
+                         resolve) symbol-doc-registry))
      (list 'do
            (list `swap! doc-registry `assoc spec-name docstring)
            (list `swap! symbol-doc-registry `assoc (list 'quote (symbol spec-name)) (list `map->Docstring {:docstring docstring}))


### PR DESCRIPTION
## Brief

Fixes nedap/speced.def#86

I couldn't write a meaningful test for it, but I could verify that it does fix the issue in the consumer project.

## QA plan

None.

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
