### PR TITLE
Only add check! in speced/let when *assert*

### DIFF
--- a/src/nedap/speced/def/impl/let_impl.cljc
+++ b/src/nedap/speced/def/impl/let_impl.cljc
@@ -12,23 +12,23 @@
 
 (defn impl [clj? bindings body]
   {:pre [(check! boolean? clj?)]}
-  (let [bindings (->> bindings
-                      (partition 2)
-                      (map (fn [[left right]]
-                             (let [analysis-result (process-name-and-tails {:tail (list [left])
-                                                                            :name nil
-                                                                            :clj? clj?})
-                                   argv (-> analysis-result :tails ffirst)
-                                   _ (assert (check! vector? argv
-                                                     #{1}    (count argv)))
-                                   left (first argv)
-                                   prepost (-> analysis-result :tails first second)
-                                   _ (assert (check! map? prepost))
-                                   assertion (-> prepost :pre)]
-                               [left right assertion])))
-                      (map (fn [[left right assertion]]
-                             {:pre [(check! some? left)]}
-                             (add-assertion [left right] assertion)))
-                      (apply concat)
-                      (vec))]
+  (let [bindings (cond-> bindings
+                   *assert* (->> (partition 2)
+                                 (map (fn [[left right]]
+                                        (let [analysis-result (process-name-and-tails {:tail (list [left])
+                                                                                       :name nil
+                                                                                       :clj? clj?})
+                                              argv (-> analysis-result :tails ffirst)
+                                              _ (assert (check! vector? argv
+                                                                #{1}    (count argv)))
+                                              left (first argv)
+                                              prepost (-> analysis-result :tails first second)
+                                              _ (assert (check! map? prepost))
+                                              assertion (-> prepost :pre)]
+                                          [left right assertion])))
+                                 (map (fn [[left right assertion]]
+                                        {:pre [(check! some? left)]}
+                                        (add-assertion [left right] assertion)))
+                                 (apply concat)
+                                 (vec)))]
     `(let ~bindings ~@body)))

--- a/test/unit/nedap/speced/def/let_test.cljc
+++ b/test/unit/nedap/speced/def/let_test.cljc
@@ -3,9 +3,7 @@
   (:require
    #?(:clj [clojure.spec.alpha :as spec] :cljs [cljs.spec.alpha :as spec])
    #?(:clj [clojure.test :refer [deftest testing are is use-fixtures]] :cljs [cljs.test :refer-macros [deftest testing is are] :refer [use-fixtures]])
-   [clojure.string :as string]
    [nedap.speced.def :as sut]
-   [nedap.speced.def.impl.parsing :as impl.parsing]
    [nedap.utils.spec.api :refer [check!]]
    [nedap.utils.test.api :refer [macroexpansion=]]
    [nedap.utils.test.api :refer [meta=]]
@@ -96,6 +94,14 @@
                         [a b])]
          (is (macroexpansion= the-let
                               specimen-1-macroexpansion))))
+     (testing "It expands without checks if `#'*assert*` is false"
+       (binding [*assert* false]
+         (let [the-let '(sut/let [a "A string"
+                                  {:keys [b]} {:b 52}
+                                  not-speced :anything]
+                          [a b])]
+           (is (macroexpansion= the-let
+                                (macroexpand-1 `(let-specimen-1)))))))
      (testing "type hint metadata is inferred (simple symbols, associative destructuring)"
        (let [[string-hinted
               _

--- a/test/unit/nedap/speced/def/let_test.cljc
+++ b/test/unit/nedap/speced/def/let_test.cljc
@@ -77,31 +77,25 @@
    (deftest macroexpansions
      (testing "It expands to a known-good, reasonable-looking form"
        (let [the-let '(clojure.core/let [a "A string"
-                                         G__440105 (nedap.utils.spec.api/check! (clojure.spec.alpha/and
-                                                                                 string?
-                                                                                 (fn [x]
-                                                                                   (if (clojure.core/class? java.lang.String)
-                                                                                     (clojure.core/instance? java.lang.String x)
-                                                                                     (clojure.core/satisfies? java.lang.String x))))
-                                                                                a)
+                                         G__440105 (clojure.core/assert
+                                                    (nedap.utils.spec.api/check! (clojure.spec.alpha/and
+                                                                                  string?
+                                                                                  (fn [x]
+                                                                                    (if (clojure.core/class? java.lang.String)
+                                                                                      (clojure.core/instance? java.lang.String x)
+                                                                                      (clojure.core/satisfies? java.lang.String x))))
+                                                                                 a))
                                          {:keys [b]} {:b 52}
-                                         G__440105 (nedap.utils.spec.api/check! (fn [x]
-                                                                                  (if (clojure.core/class? java.lang.Long)
-                                                                                    (clojure.core/instance? java.lang.Long x)
-                                                                                    (clojure.core/satisfies? java.lang.Long x)))
-                                                                                b)
+                                         G__440105 (clojure.core/assert
+                                                    (nedap.utils.spec.api/check! (fn [x]
+                                                                                   (if (clojure.core/class? java.lang.Long)
+                                                                                     (clojure.core/instance? java.lang.Long x)
+                                                                                     (clojure.core/satisfies? java.lang.Long x)))
+                                                                                 b))
                                          not-speced :anything]
                         [a b])]
          (is (macroexpansion= the-let
                               specimen-1-macroexpansion))))
-     (testing "It expands without checks if `#'*assert*` is false"
-       (binding [*assert* false]
-         (let [the-let '(sut/let [a "A string"
-                                  {:keys [b]} {:b 52}
-                                  not-speced :anything]
-                          [a b])]
-           (is (macroexpansion= the-let
-                                (macroexpand-1 `(let-specimen-1)))))))
      (testing "type hint metadata is inferred (simple symbols, associative destructuring)"
        (let [[string-hinted
               _


### PR DESCRIPTION
## Brief

fixes #93. wraps `check!` call in `assert`

`letfn` doesn't need a fix, because it relies on `:post` / `:pre` :)

## QA plan

green tests

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [x] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [x] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Modular design
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [x] Breaking API changes
  * [x] Cross-compatibility (Clojure/ClojureScript)
