### PR TITLE
Add clj-kondo config

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,11 @@
                                    :password :env/clojars_pass}}
   :target-path "target/%s"
 
-  :test-paths ["src" "test"]
+  :source-paths ["src"]
+
+  :test-paths ["test"]
+
+  :resource-paths ["resources"]
 
   :monkeypatch-clojure-test false
 

--- a/resources/clj-kondo.exports/nedap/speced.def/config.edn
+++ b/resources/clj-kondo.exports/nedap/speced.def/config.edn
@@ -1,0 +1,7 @@
+{:lint-as {nedap.speced.def/def-with-doc clojure.core/defonce
+           nedap.speced.def/defn         clojure.core/defn
+           nedap.speced.def/defprotocol  clojure.core/defprotocol
+           nedap.speced.def/doc          clojure.repl/doc
+           nedap.speced.def/fn           clojure.core/fn
+           nedap.speced.def/let          clojure.core/let
+           nedap.speced.def/letfn        clojure.core/letfn}}


### PR DESCRIPTION
## Brief

Adds config for clj-kondo which can be imported by consumers using `--copy-configs` (see [readme](https://github.com/clj-kondo/clj-kondo#project-setup)).

The config was added according to https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#exporting-and-importing-configuration

Config taken from formatting-stack, where it has been running in production for a long time :)
https://github.com/nedap/formatting-stack/blob/df434ccb4f5bed605e40bcec01a32d0760f5df37/src/formatting_stack/linters/kondo.clj#L30-L39

<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

1. create corpus
```clj
(ns corpus
  (:require
   [nedap.speced.def :as speced]))

(speced/defn print-string [^string? s]
  (println s))

(print-string "test")
```
  2. `clj-kondo --lint ./corpus.clj`
      - observe `"./corpus.clj:5:37: error: Unresolved symbol: s"`
  3. `lein install` this version of speced.def
  4. run `clj-kondo --lint "$(lein classpath)" --dependencies --parallel --copy-configs`
      - observe `"Imported config to .clj-kondo/nedap/speced.def. To activate, add "nedap/speced.def" to :config-paths in .clj-kondo/config.edn."`
  5. add "nedap/speced.def" to :config-paths in .clj-kondo/config.edn.
  6. run `clj-kondo --lint ./corpus.clj`
     - observe `"linting took 20ms, errors: 0, warnings: 0"`

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
