### PR TITLE
Add clj-kondo analyzer hook for defprotocol

### DIFF
--- a/resources/clj-kondo.exports/nedap/speced.def/config.edn
+++ b/resources/clj-kondo.exports/nedap/speced.def/config.edn
@@ -4,4 +4,5 @@
            nedap.speced.def/doc          clojure.repl/doc
            nedap.speced.def/fn           clojure.core/fn
            nedap.speced.def/let          clojure.core/let
-           nedap.speced.def/letfn        clojure.core/letfn}}
+           nedap.speced.def/letfn        clojure.core/letfn}
+ :hooks   {:analyze-call {nedap.speced.def/defprotocol hooks.speced.def/defprotocol-hook}}}

--- a/resources/clj-kondo.exports/nedap/speced.def/hooks/speced/def.clj
+++ b/resources/clj-kondo.exports/nedap/speced.def/hooks/speced/def.clj
@@ -1,0 +1,17 @@
+(ns hooks.speced.def
+  (:require
+   [clj-kondo.hooks-api :as api]))
+
+(defn defprotocol-hook [{{:keys [children] :as node} :node}]
+  (let [[_macro protocol-name docstring & methods] children]
+    {:node (api/list-node ;; defprotocol with renamed fn names
+            (list*
+             (api/token-node 'clojure.core/defprotocol)
+             protocol-name
+             docstring
+             (concat
+              methods
+              (->> methods
+                   (map (fn [{[fn-token & xs] :children}]
+                          (api/list-node
+                           (list* (api/token-node (symbol (str "--" (:string-value fn-token)))) xs))))))))}))


### PR DESCRIPTION
## Brief

`speced/defprotocol` creates two methods for each method. An internal one for implementation (prefixed with `--`) and a public one which is speced. The internal one is not recognized by clj-kondo and triggers a `Unresolved symbol` warning 

This PR extends #107 with an analyzer hook (https://github.com/clj-kondo/clj-kondo/blob/master/doc/hooks.md) which expands `speced/defprotocol`-calls to a form which defines both internal and the public fn.

<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

 1. create corpus
```clj
(ns corpus
  (:require
   [nedap.speced.def :as speced]))

(speced/defprotocol Example
  "An example"
  (print-string [this ^string? s]))

(def example
 ^{--print-string (fn [_this s] (println s))}
  {})

(print-string example "test")
```
  2. `clj-kondo --lint ./corpus.clj`
      - observe `"./corpus.clj:10:4: error: Unresolved symbol: --print-string"`
  3. bump speced.def to `2.1.0-alpha1`
  4. run `clj-kondo --lint "$(lein classpath)" --dependencies --parallel --copy-configs`
      - observe `"Imported config to .clj-kondo/nedap/speced.def. To activate, add "nedap/speced.def" to :config-paths in .clj-kondo/config.edn."`
  5. add "nedap/speced.def" to :config-paths in .clj-kondo/config.edn.
  6. run `clj-kondo --lint ./corpus.clj`
     - observe `"linting took 20ms, errors: 0, warnings: 0"`

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [x] I have checked out this branch and reviewed it locally, running it
* [x] I have QAed the functionality
* [x] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
